### PR TITLE
Support passing `false` to `deploy` argument

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ const noop = () => {};
 
 export function useInterval(
   callback: () => void,
-  delay: number | null,
+  delay: number | null | false,
   immediate?: boolean
 ) {
   const savedCallback = useRef(noop);
@@ -19,13 +19,13 @@ export function useInterval(
   // Execute callback if immediate is set.
   useEffect(() => {
     if (!immediate) return;
-    if (delay === null) return;
+    if (delay === null || delay === false) return;
     savedCallback.current();
   }, [immediate]);
 
   // Set up the interval.
   useEffect(() => {
-    if (delay === null) return undefined;
+    if (delay === null || delay === false) return undefined;
     const tick = () => savedCallback.current();
     const id = setInterval(tick, delay);
     return () => clearInterval(id);

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -6,7 +6,7 @@ beforeEach(cleanup);
 
 type IntervalProps = {
   fn: () => void;
-  delay: number | null;
+  delay: number | null | false;
   immediate?: boolean;
 };
 

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -48,6 +48,12 @@ describe('useInterval', () => {
       expect(fn).toBeCalledTimes(4);
     });
 
+    it('cancels interval when delay is false', () => {
+      render(<Interval immediate fn={fn} delay={false} />, { container });
+      jest.advanceTimersByTime(1500);
+      expect(fn).toBeCalledTimes(4);
+    });
+
     jest.clearAllTimers();
   });
 
@@ -65,6 +71,12 @@ describe('useInterval', () => {
 
     it('cancels interval when delay is null', () => {
       render(<Interval immediate fn={fn} delay={null} />, { container });
+      jest.advanceTimersByTime(1500);
+      expect(fn).toBeCalledTimes(5);
+    });
+
+    it('cancels interval when delay is false', () => {
+      render(<Interval immediate fn={fn} delay={false} />, { container });
       jest.advanceTimersByTime(1500);
       expect(fn).toBeCalledTimes(5);
     });


### PR DESCRIPTION
Fixes #4 

Allows

```
  useInterval(() => {
    if (currentStep >= steps.length - 1) {
      setIsPlaying(false);

      return;
    }
    setCurrentStep(step => step + 1);
  }, isPlaying && 200);
```

Typings prevent `true`:

```
  useInterval(() => {
    if (currentStep >= steps.length - 1) {
      setIsPlaying(false);

      return;
    }
    setCurrentStep(step => step + 1);
  }, isPlaying || 200);
// Error:(98, 6) TS2345: Argument of type 'true | 200' is not assignable to parameter of type 'number | false | null'.
//  Type 'true' is not assignable to type 'number | false | null'.
```