### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "Hermanya/use-interval",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
   "engines": {


### PR DESCRIPTION
This is to TypeScript what `main` is to `node`.

Currently WebStorm will import from `use-internal/dist`, since that's where the `index.d.ts` is.