### PR TITLE
Make library work with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
None of the APIs that this library uses have changed in React 17, however it dictates it must be used together with React 16.8 in `package.json`. This change modifies that to be 16.8 or newer.

```
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from use-interval@1.3.0
npm ERR! node_modules/use-interval
npm ERR!   use-interval@"^1.3.0" from the root project
```

(And yes, I have confirmed the library does indeed play nicely with React 17.)