### PR TITLE
Allow React 17+ as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0 || ^17"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
Looks like you already use React 17 as a dev dependency and the library doesn't rely on any new features. Adding the additional version makes it possible to use the hook also in React 17 codebases.