### PR TITLE
Save a few bytes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,14 +18,13 @@ export function useInterval(
 
   // Execute callback if immediate is set.
   useEffect(() => {
-    if (!immediate) return;
-    if (delay === null || delay === false) return;
+    if (!immediate || delay === null || delay === false) return;
     savedCallback.current();
   }, [immediate]);
 
   // Set up the interval.
   useEffect(() => {
-    if (delay === null || delay === false) return undefined;
+    if (delay === null || delay === false) return;
     const tick = () => savedCallback.current();
     const id = setInterval(tick, delay);
     return () => clearInterval(id);


### PR DESCRIPTION
I figure since this seems to be the most used `setInterval` hook, even shaving a few bytes off the file size could make a difference in aggregate :)

Before making this change I built the project locally. Even after compiling, the unnecessary `undefined` remains in the source.

I tried not to make any changes that would affect readability.

| **File size** | Compiled | Gzipped   |
|---------------|----------|-----------|
| Before        | 1.08 KiB | 479 bytes |
| After         | 1.04 KiB | 468 bytes |